### PR TITLE
Command line argument processing

### DIFF
--- a/Nightwatch.Tests/CLI.fs
+++ b/Nightwatch.Tests/CLI.fs
@@ -1,0 +1,32 @@
+module Nightwatch.Tests.CLI
+
+open System
+open System.IO
+open System.Text
+open System.Threading.Tasks
+
+open Xunit
+open Argu
+
+open Nightwatch.Program
+
+[<Fact>]
+let ``Config path should be parsed correctly`` () =
+    let parser = ArgumentParser.Create<CLIArguments>()
+    let testPath = "test/dir/"
+
+    let expected = [ CLIArguments.Arguments testPath ]
+    let parseResult = parser.Parse [| testPath |]
+    let result = parseResult.GetAllResults()
+
+    Assert.Equal<CLIArguments list>(expected, result)
+
+[<Fact>]
+let ``Version option should be parsed correclty`` () =
+    let parse = ArgumentParser.Create<CLIArguments>()
+
+    let expected = [ CLIArguments.Version ]
+    let parseResult = parse.Parse [| "--version" |]
+    let result = parseResult.GetAllResults()
+
+    Assert.Equal<CLIArguments list>(expected, result)

--- a/Nightwatch.Tests/Cli.fs
+++ b/Nightwatch.Tests/Cli.fs
@@ -1,4 +1,4 @@
-module Nightwatch.Tests.CLI
+module Nightwatch.Tests.Cli
 
 open System
 open System.IO
@@ -12,21 +12,21 @@ open Nightwatch.Program
 
 [<Fact>]
 let ``Config path should be parsed correctly`` () =
-    let parser = ArgumentParser.Create<CLIArguments>()
+    let parser = ArgumentParser.Create<CliArguments>()
     let testPath = "test/dir/"
 
-    let expected = [ CLIArguments.Arguments testPath ]
+    let expected = [ CliArguments.Arguments testPath ]
     let parseResult = parser.Parse [| testPath |]
     let result = parseResult.GetAllResults()
 
-    Assert.Equal<CLIArguments list>(expected, result)
+    Assert.Equal<CliArguments list>(expected, result)
 
 [<Fact>]
 let ``Version option should be parsed correclty`` () =
-    let parse = ArgumentParser.Create<CLIArguments>()
+    let parse = ArgumentParser.Create<CliArguments>()
 
-    let expected = [ CLIArguments.Version ]
+    let expected = [ CliArguments.Version ]
     let parseResult = parse.Parse [| "--version" |]
     let result = parseResult.GetAllResults()
 
-    Assert.Equal<CLIArguments list>(expected, result)
+    Assert.Equal<CliArguments list>(expected, result)

--- a/Nightwatch.Tests/Nightwatch.Tests.fsproj
+++ b/Nightwatch.Tests/Nightwatch.Tests.fsproj
@@ -1,11 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Core/FileSystem.fs" />
     <Compile Include="Core/Network.fs" />
@@ -14,15 +11,13 @@
     <Compile Include="Resources/Shell.fs" />
     <Compile Include="Configuration.fs" />
     <Compile Include="Scheduler.fs" />
+    <Compile Include="CLI.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-
     <ProjectReference Include="../Nightwatch/Nightwatch.fsproj" />
   </ItemGroup>
-
 </Project>

--- a/Nightwatch.Tests/Nightwatch.Tests.fsproj
+++ b/Nightwatch.Tests/Nightwatch.Tests.fsproj
@@ -11,7 +11,7 @@
     <Compile Include="Resources/Shell.fs" />
     <Compile Include="Configuration.fs" />
     <Compile Include="Scheduler.fs" />
-    <Compile Include="CLI.fs" />
+    <Compile Include="Cli.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/Nightwatch/Nightwatch.fsproj
+++ b/Nightwatch/Nightwatch.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Argu" Version="3.7.0" />
     <PackageReference Include="FSharp.Control.FusionTasks.FS41" Version="1.1.0" />
     <PackageReference Include="Quartz" Version="3.0.0-alpha3" />
     <PackageReference Include="YamlDotNet" Version="4.2.1" />

--- a/Nightwatch/Program.fs
+++ b/Nightwatch/Program.fs
@@ -92,7 +92,7 @@ let private run = function
     ExitCodes.configurationError
 
 [<RequireQualifiedAccess>]
-type CLIArguments =
+type CliArguments =
     | Version
     | [<MainCommand>] Arguments of configPath:string
     interface IArgParserTemplate with
@@ -103,14 +103,14 @@ type CLIArguments =
 
 [<EntryPoint>]
 let main argv =
-    let parser = ArgumentParser.Create<CLIArguments>(programName = "nightwatch")
+    let parser = ArgumentParser.Create<CliArguments>(programName = "nightwatch")
     let results = parser.ParseCommandLine(argv, raiseOnUsage = false)
 
-    if results.Contains <@ CLIArguments.Version @> then
+    if results.Contains <@ CliArguments.Version @> then
         printfn "%A" version
         ExitCodes.success
-    else if results.Contains <@ CLIArguments.Arguments @> then
-        let configPath = results.GetResult <@ CLIArguments.Arguments @>
+    else if results.Contains <@ CliArguments.Arguments @> then
+        let configPath = results.GetResult <@ CliArguments.Arguments @>
 
         printfn "%s" fullVersion
         configureResourceRegistry()

--- a/Nightwatch/Program.fs
+++ b/Nightwatch/Program.fs
@@ -58,7 +58,7 @@ let private errorsToString errors =
     let printError { path = (Path path); id = id; message = message } =
         sprintf "Path: %s\nId: %s\nMessage: %s"
             path
-            (match id with Some x -> x | None -> "N/A")
+            (defaultArg id "N/A")
             message
 
     String.Join("\n", Seq.map printError errors)
@@ -103,7 +103,7 @@ type CLIArguments =
 [<EntryPoint>]
 let main argv =
     let parser = ArgumentParser.Create<CLIArguments>(programName = "nightwatch")
-    let results = parser.ParseCommandLine(argv, raiseOnUsage=false)
+    let results = parser.ParseCommandLine(argv, raiseOnUsage = false)
 
     if results.Contains <@ Version @> then
         printfn "%A" version

--- a/Nightwatch/Program.fs
+++ b/Nightwatch/Program.fs
@@ -91,6 +91,7 @@ let private run = function
     printfn "%s" (errorsToString errors)
     ExitCodes.configurationError
 
+[<RequireQualifiedAccess>]
 type CLIArguments =
     | Version
     | [<MainCommand>] Arguments of configPath:string
@@ -105,11 +106,11 @@ let main argv =
     let parser = ArgumentParser.Create<CLIArguments>(programName = "nightwatch")
     let results = parser.ParseCommandLine(argv, raiseOnUsage = false)
 
-    if results.Contains <@ Version @> then
+    if results.Contains <@ CLIArguments.Version @> then
         printfn "%A" version
         ExitCodes.success
-    else if results.Contains <@ Arguments @> then
-        let configPath = results.GetResult <@ Arguments @>
+    else if results.Contains <@ CLIArguments.Arguments @> then
+        let configPath = results.GetResult <@ CLIArguments.Arguments @>
 
         printfn "%s" fullVersion
         configureResourceRegistry()


### PR DESCRIPTION
Closes #12 

- [x] Simple extensible CLI via Argu
- [x] Add `--version` option
- [x] Add tests

Unsolved questions:

- Should we add default configuration file path? _// I don't think so._

Result:

```
USAGE: nightwatch [--help] [--version] [<configPath>]

ARGUMENTS:

    <configPath>          path to config directory

OPTIONS:

    --version             display nightwatch's version
    --help                display this list of options.
```